### PR TITLE
Add Maven CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Build with Maven
+        run: ./mvnw -B verify
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            target/**/*.jar
+            target/**/*.war
+          if-no-files-found: ignore
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: target/surefire-reports/
+          if-no-files-found: ignore
+


### PR DESCRIPTION
## Summary
- run `./mvnw -B verify` on pushes to `main` and all pull requests
- upload build artifacts and test results

## Testing
- `./mvnw -B verify` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686946018aac8327a535092ecd94f359