### PR TITLE
Implement proxy handlers and routing

### DIFF
--- a/src/main/java/org/workshop/learn_proxy/proxy/ProxyRoutes.java
+++ b/src/main/java/org/workshop/learn_proxy/proxy/ProxyRoutes.java
@@ -1,0 +1,33 @@
+package org.workshop.learn_proxy.proxy;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.workshop.learn_proxy.proxy.forward.ForwardProxyHandler;
+import org.workshop.learn_proxy.proxy.reverse.ReverseProxyHandler;
+
+@Configuration
+public class ProxyRoutes {
+
+    private final ForwardProxyHandler forwardProxyHandler;
+    private final ReverseProxyHandler reverseProxyHandler;
+
+    public ProxyRoutes(ForwardProxyHandler forwardProxyHandler,
+                       ReverseProxyHandler reverseProxyHandler) {
+        this.forwardProxyHandler = forwardProxyHandler;
+        this.reverseProxyHandler = reverseProxyHandler;
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> proxyRouter() {
+        return RouterFunctions.route()
+                .path("/proxy/forward", builder ->
+                        builder.route(RequestPredicates.all(), forwardProxyHandler::handleRequest))
+                .path("/proxy/reverse", builder ->
+                        builder.route(RequestPredicates.all(), reverseProxyHandler::handleRequest))
+                .build();
+    }
+}

--- a/src/main/java/org/workshop/learn_proxy/proxy/forward/ForwardProxyHandler.java
+++ b/src/main/java/org/workshop/learn_proxy/proxy/forward/ForwardProxyHandler.java
@@ -1,0 +1,35 @@
+package org.workshop.learn_proxy.proxy.forward;
+
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+@Component
+public class ForwardProxyHandler {
+
+    private final WebClient webClient;
+
+    public ForwardProxyHandler(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder
+                .clientConnector(new ReactorClientHttpConnector(
+                        HttpClient.create().proxyWithSystemProperties()
+                ))
+                .build();
+    }
+
+    public Mono<ServerResponse> handleRequest(ServerRequest request) {
+        return webClient.method(request.method())
+                .uri(request.uri())
+                .headers(headers -> headers.addAll(request.headers().asHttpHeaders()))
+                .body(request.bodyToMono(String.class), String.class)
+                .exchangeToMono(clientResponse ->
+                        ServerResponse.status(clientResponse.statusCode())
+                                .headers(h -> h.addAll(clientResponse.headers().asHttpHeaders()))
+                                .body(clientResponse.bodyToMono(String.class), String.class)
+                );
+    }
+}

--- a/src/main/java/org/workshop/learn_proxy/proxy/reverse/ReverseProxyHandler.java
+++ b/src/main/java/org/workshop/learn_proxy/proxy/reverse/ReverseProxyHandler.java
@@ -1,0 +1,54 @@
+package org.workshop.learn_proxy.proxy.reverse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class ReverseProxyHandler {
+
+    private final List<String> backendServers;
+    private final AtomicInteger currentIndex = new AtomicInteger(0);
+    private final WebClient webClient;
+
+    public ReverseProxyHandler(WebClient.Builder webClientBuilder) {
+        this.backendServers = Arrays.asList(
+                "http://backend1:8080",
+                "http://backend2:8080",
+                "http://backend3:8080"
+        );
+        this.webClient = webClientBuilder.build();
+    }
+
+    public Mono<ServerResponse> handleRequest(ServerRequest request) {
+        String backendUrl = getNextBackendServer();
+        String targetUrl = backendUrl + request.path();
+
+        return webClient.method(request.method())
+                .uri(targetUrl)
+                .headers(headers -> {
+                    headers.addAll(request.headers().asHttpHeaders());
+                    headers.remove("host");
+                })
+                .body(request.bodyToMono(String.class), String.class)
+                .exchangeToMono(this::buildResponse);
+    }
+
+    private String getNextBackendServer() {
+        int index = currentIndex.getAndIncrement() % backendServers.size();
+        return backendServers.get(index);
+    }
+
+    private Mono<ServerResponse> buildResponse(ClientResponse clientResponse) {
+        return ServerResponse.status(clientResponse.statusCode())
+                .headers(headers -> headers.addAll(clientResponse.headers().asHttpHeaders()))
+                .body(clientResponse.bodyToMono(String.class), String.class);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ForwardProxyHandler` and `ReverseProxyHandler` implementing proxy logic
- wire up `/proxy/forward/**` and `/proxy/reverse/**` routes using a `ProxyRoutes` router

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6869460750cc8327b853c9f7c328213f