### PR TITLE
Add proxy controller tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/workshop/learn_proxy/BasicProxyController.java
+++ b/src/main/java/org/workshop/learn_proxy/BasicProxyController.java
@@ -1,0 +1,37 @@
+package org.workshop.learn_proxy;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class BasicProxyController {
+
+    private final WebClient webClient;
+
+    public BasicProxyController(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.build();
+    }
+
+    @GetMapping("/proxy/**")
+    public Mono<ResponseEntity<String>> proxyRequest(ServerHttpRequest request,
+                                                     @RequestParam String target) {
+        String path = request.getPath().value().substring("/proxy".length());
+        String targetUrl = target + path;
+
+        return webClient.get()
+                .uri(targetUrl)
+                .headers(headers ->
+                        request.getHeaders().forEach((key, values) -> {
+                            if (!key.equalsIgnoreCase("host")) {
+                                headers.addAll(key, values);
+                            }
+                        }))
+                .retrieve()
+                .toEntity(String.class);
+    }
+}

--- a/src/test/java/org/workshop/learn_proxy/BasicProxyControllerTest.java
+++ b/src/test/java/org/workshop/learn_proxy/BasicProxyControllerTest.java
@@ -1,0 +1,80 @@
+package org.workshop.learn_proxy;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class BasicProxyControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    private MockWebServer backend;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        backend = new MockWebServer();
+        backend.start();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        backend.shutdown();
+    }
+
+    @Test
+    void proxyForwardsRequestAndReturnsBody() throws Exception {
+        backend.enqueue(new MockResponse().setBody("from backend").setResponseCode(200));
+
+        String target = backend.url("/").toString();
+
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/proxy/test")
+                        .queryParam("target", target)
+                        .build())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class).isEqualTo("from backend");
+
+        RecordedRequest recorded = backend.takeRequest();
+        assertThat(recorded.getPath()).isEqualTo("/test");
+    }
+
+    @Test
+    void proxyForwardsResponseHeaders() throws Exception {
+        backend.enqueue(new MockResponse()
+                .setBody("body")
+                .addHeader("X-Test", "value"));
+
+        String target = backend.url("/").toString();
+
+        webTestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/proxy/hello")
+                        .queryParam("target", target)
+                        .build())
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().valueEquals("X-Test", "value")
+                .expectBody(String.class).isEqualTo("body");
+
+        RecordedRequest recorded = backend.takeRequest();
+        assertThat(recorded.getPath()).isEqualTo("/hello");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `BasicProxyController` to forward requests
- test request forwarding and header propagation with `MockWebServer`
- add `mockwebserver` test dependency

## Testing
- `./mvnw -q test` *(fails: could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686946089290832788445a8d024cb7da